### PR TITLE
Clean up base docker image (on fork)

### DIFF
--- a/.github/workflows/build_test_and_deploy.yml
+++ b/.github/workflows/build_test_and_deploy.yml
@@ -1,0 +1,105 @@
+# Copyright (c) 2022 ETH Zurich
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+name: Build, test and deploy docker images
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  # Build base docker image
+  build_base_image:
+    name: github/pika-ci-base/fast
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_PASS }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: Dockerfile.base
+          push: true
+          tags: ${{ secrets.DOCKER_USER }}/pika-ci-base:latest,${{ secrets.DOCKER_USER }}/pika-ci-base:1
+
+#env:
+#  IMAGE_NAME_LATEST: pikaorg/pika-ci-base:latest
+#  IMAGE_NAME_VERSIONED: pikaorg/pika-ci-base:1
+#    steps:
+#      - uses: actions/checkout@v3
+#      - name: Build base docker image
+#    #    uses: docker/login-action@v1
+#        shell: bash
+#        run: |
+#          echo "Hello World"
+#          docker build -f Dockerfile.base -t ${IMAGE_NAME_LATEST} .
+#          docker tag ${IMAGE_NAME_LATEST} ${IMAGE_NAME_VERSIONED}
+#          docker images
+#    - name: Test base docker image
+#      shell: bash
+#      run: |
+#          docker run ${IMAGE_NAME_LATEST} cmake --version
+#          git clone https://github.com/pika-org/pika.git --depth=1
+#          docker run ${IMAGE_NAME_LATEST} printenv
+#          docker create -v /pika --name app ${IMAGE_NAME_LATEST} /bin/true
+#          docker cp /root/project/pika/./ app:/pika
+#          docker run --volumes-from app ${IMAGE_NAME_LATEST} mkdir /pika/build
+#          docker run --volumes-from app -w /pika/build ${IMAGE_NAME_LATEST} cmake .. -DPIKA_WITH_MALLOC=jemalloc -G Ninja
+#          docker run --volumes-from app -w /pika/build ${IMAGE_NAME_LATEST} ninja core
+#    - name: Deploy base docker image
+#      shell: bash
+#      run: |
+#          if [ "${CIRCLE_BRANCH}" == "main" ]; then
+#              docker login -u ${{ secrets.DOCKER_USER }} -p ${{ secrets.DOCKER_PASS }}
+#              docker push ${IMAGE_NAME_LATEST}
+#              docker push ${IMAGE_NAME_VERSIONED}
+#          fi
+
+#  # Build hip docker image
+#  build_hip_image:
+#    name: github/pika-ci-hip/fast
+#    needs: build_base_image
+#    runs-on: ubuntu-latest
+#    container: docker:17.05.0-ce-git
+#    env:
+#      IMAGE_NAME_LATEST: pikaorg/pika-ci-hip:latest
+#      IMAGE_NAME_VERSIONED: pikaorg/pika-ci-hip:1
+#
+#    steps:
+#    - uses: actions/checkout@v3
+#    - name: Build hip docker image
+#      shell: bash
+#      run: |
+#          docker build -f Dockerfile.base -t ${IMAGE_NAME_LATEST} .
+#          docker tag ${IMAGE_NAME_LATEST} ${IMAGE_NAME_VERSIONED}
+#          docker images
+#    - name: Test hip docker image
+#      shell: bash
+#      run: |
+#          docker run ${IMAGE_NAME_LATEST} cmake --version
+#          git clone https://github.com/pika-org/pika.git --depth=1
+#          docker run ${IMAGE_NAME_LATEST} printenv
+#          docker create -v /pika --name app ${IMAGE_NAME_LATEST} /bin/true
+#          docker cp /root/project/pika/./ app:/pika
+#          docker run --volumes-from app ${IMAGE_NAME_LATEST} mkdir /pika/build
+#          docker run --volumes-from app -w /pika/build ${IMAGE_NAME_LATEST} cmake .. -DPIKA_WITH_MALLOC=jemalloc -G Ninja
+#          docker run --volumes-from app -w /pika/build ${IMAGE_NAME_LATEST} ninja core
+#    - name: Deploy hip docker image
+#      shell: bash
+#      run: |
+#          if [ "${CIRCLE_BRANCH}" == "main" ]; then
+#              docker login -u ${{ secrets.DOCKER_USER }} -p ${{ secrets.DOCKER_PASS }}
+#              docker push ${IMAGE_NAME_LATEST}
+#              docker push ${IMAGE_NAME_VERSIONED}
+#          fi

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -36,44 +36,24 @@ RUN apt-get update -qq && apt-get install -y -qq    \
                     clang                           \
                     clang-format-11                 \
                     clang-tidy                      \
-                    jq                              \
-                    kmod                            \
-                    llvm                            \
                     lld                             \
+                    llvm                            \
                     llvm-dev                        \
-                    libasio-dev                     \
                     libclang-dev                    \
                     libhwloc-dev                    \
                     libjemalloc-dev                 \
-                    libboost-atomic-dev             \
-                    libboost-chrono-dev             \
-                    libboost-date-time-dev          \
-                    libboost-filesystem-dev         \
-                    libboost-iostreams-dev          \
-                    libboost-program-options-dev    \
                     libboost-regex-dev              \
-                    libboost-system-dev             \
-                    libboost-thread-dev             \
                     libgoogle-perftools-dev         \
                     mpi-default-dev                 \
-                    vc-dev                          \
-                    doxygen                         \
-                    python3                         \
-                    python3-pip                     \
-                    texlive                         \
-                    texlive-latex-extra             \
-                    latexmk                         \
-                    libjson-perl                    \
                     ninja-build                     \
+                    python3 python3-pip             \
                     codespell                       \
                     git                             \
                     xsltproc                        \
                     rpm                             \
-                    pkg-config                      \
                     graphviz                        \
                     iwyu                            \
-                    devscripts                      \
-                    wget
+                    devscripts
 
 # Get cmake files (in separate RUN command to get cached)
 RUN wget -q https://cmake.org/files/v3.19/cmake-3.19.8-Linux-x86_64.tar.gz -O cmake.tar.gz && \
@@ -81,33 +61,19 @@ RUN wget -q https://cmake.org/files/v3.19/cmake-3.19.8-Linux-x86_64.tar.gz -O cm
     tar --strip-components=1 -C /usr/local -xf cmake.tar.gz && \
     rm cmake.tar.gz
 
+# Install grcov and cpp-dependencies
 RUN wget -q https://github.com/mozilla/grcov/releases/download/v0.7.1/grcov-linux-x86_64.tar.bz2 -O grcov.tar.bz2 && \
     echo "603196293bed54d7ec6fb6d6f85db27966c4512235c7bd6555e1082e765c5bd2 grcov.tar.bz2" | sha256sum --check --status && \
     tar -jxf grcov.tar.bz2 && \
     mv grcov /usr/bin && \
     rm grcov.tar.bz2
 
-# NOTE: breathe is pinned to 4.16.0 as 4.17.0 introduced a regression in
-# handling "friend struct x;", see
-# https://github.com/michaeljones/breathe/issues/521. The pinned version can be
-# removed when the issue has been resolved.
-RUN pip3 install sphinx==3.5.4 breathe==4.16.0 sphinx-rtd-theme sphinx-book-theme sphinxcontrib-bibtex insegel cmake_format && \
-    rm /usr/bin/ld && ln -s /usr/bin/ld.lld /usr/bin/ld && cd /tmp && \
+RUN rm /usr/bin/ld && ln -s /usr/bin/ld.lld /usr/bin/ld && cd /tmp && \
     git clone https://github.com/tomtom-international/cpp-dependencies.git && \
-    cd cpp-dependencies && cmake . && make -j install && \
+    cd cpp-dependencies && cmake -DWITH_BOOST=OFF . && make -j install && \
     cd /tmp && rm -rf /tmp/cpp-dependencies && \
-    git clone --single-branch --branch clang_10 https://github.com/include-what-you-use/include-what-you-use.git && \
-    mkdir -p include-what-you-use/build && cd include-what-you-use/build && \
-    cmake -DCMAKE_PREFIX_PATH="/usr/lib/llvm-10" -DCMAKE_INSTALL_PREFIX="/usr" .. && make -j install && \
-    cd /tmp && rm -rf include-what-you-use && \
-    git clone --single-branch --branch 1.4.1 https://github.com/VcDevel/Vc.git && \
-    cd Vc && git submodule update --init && \
-    mkdir -p build && cd build && \
-    cmake -DBUILD_TESTING=OFF .. && make -j install && \
-    cd /tmp && rm -rf Vc && \
     rm -rf /var/lib/apt/lists/*
 
-ENV CC clang
 ENV CXX clang++
 
 # IMPORTANT: Did you read the note at the top of the file?


### PR DESCRIPTION
Remove obsolete dependencies like:
- asio
- boost (atomic, chrono, date-time, filesystem, iostreams, program-options, thread, system)
- packages related to docs (latex, doxygen, etc.), we can move this to a documentation image. Note: python is still necessary to install the `cmake_format` pip package
- installation of include-what-you-use since the package `iwyu` is in the `apt install` list
- `wget` as duplicated
- `pkg-config` not in pika anymore
- `Vc` as we plan to remove its support in pika (replaced by `std::experimental::simd`)
- `kmod` and `jq` as used in `roll_release.sh`

Fixes partially https://github.com/pika-org/pika/issues/10

TODO:
- [ ] Add a CI step to build the image
- [ ] Test it with pika