### PR TITLE
Clean up base docker image

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -14,7 +14,7 @@ on:
     branches: main
 
 env:
-  version: 1
+  version: 2
   base_image_name: pika-ci-base
   hip_image_name: pika-ci-hip
 
@@ -22,7 +22,6 @@ jobs:
 
   # Build base and HIP docker images
   build_and_deploy:
-    # Cannot use the env variables in the name
     name: Build and deploy images
     runs-on: ubuntu-latest
     steps:
@@ -33,20 +32,23 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_PASS }}
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-      # The deploy step is only triggered on merge of the pull request
-      - name: Build and deploy base image
+      - name: Build base image
         uses: docker/build-push-action@v2
         with:
-          context: .
           file: Dockerfile.base
           tags: ${{ secrets.DOCKER_USER }}/${{ env.base_image_name }}:latest,${{ secrets.DOCKER_USER }}/${{ env.base_image_name }}:${{ env.version }}
-          push: ${{ contains(github.ref, 'main') }}
+          load: true
+      - name: Push base image
+        uses: docker/build-push-action@v2
+        if: ${{ github.ref == 'refs/heads/main' }}
+        with:
+          file: Dockerfile.base
+          tags: ${{ secrets.DOCKER_USER }}/${{ env.base_image_name }}:latest,${{ secrets.DOCKER_USER }}/${{ env.base_image_name }}:${{ env.version }}
+          push: true
       - name: Build and deploy HIP image
         uses: docker/build-push-action@v2
         with:
-          context: .
           file: Dockerfile.hip
+          build-args: BASE_IMAGE=${{ secrets.DOCKER_USER }}/${{ env.base_image_name }}:${{ env.version }}
           tags: ${{ secrets.DOCKER_USER }}/${{ env.hip_image_name }}:latest,${{ secrets.DOCKER_USER }}/${{ env.hip_image_name }}:${{ env.version }}
-          push: ${{ contains(github.ref, 'main') }}
+          push: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -1,0 +1,52 @@
+# Copyright (c) 2022 ETH Zurich
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+name: Build and deploy docker images
+
+# The builds are triggered with pushes on the 'main' branch or with a pull
+# request against the 'main' branch
+on:
+  pull_request:
+  push:
+    branches: main
+
+env:
+  version: 1
+  base_image_name: pika-ci-base
+  hip_image_name: pika-ci-hip
+
+jobs:
+
+  # Build base and HIP docker images
+  build_and_deploy:
+    # Cannot use the env variables in the name
+    name: Build and deploy images
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_PASS }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      # The deploy step is only triggered on merge of the pull request
+      - name: Build and deploy base image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: Dockerfile.base
+          tags: ${{ secrets.DOCKER_USER }}/${{ env.base_image_name }}:latest,${{ secrets.DOCKER_USER }}/${{ env.base_image_name }}:${{ env.version }}
+          push: ${{ contains(github.ref, 'main') }}
+      - name: Build and deploy HIP image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: Dockerfile.hip
+          tags: ${{ secrets.DOCKER_USER }}/${{ env.hip_image_name }}:latest,${{ secrets.DOCKER_USER }}/${{ env.hip_image_name }}:${{ env.version }}
+          push: ${{ contains(github.ref, 'main') }}

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -36,44 +36,24 @@ RUN apt-get update -qq && apt-get install -y -qq    \
                     clang                           \
                     clang-format-11                 \
                     clang-tidy                      \
-                    jq                              \
-                    kmod                            \
-                    llvm                            \
                     lld                             \
+                    llvm                            \
                     llvm-dev                        \
-                    libasio-dev                     \
                     libclang-dev                    \
                     libhwloc-dev                    \
                     libjemalloc-dev                 \
-                    libboost-atomic-dev             \
-                    libboost-chrono-dev             \
-                    libboost-date-time-dev          \
-                    libboost-filesystem-dev         \
-                    libboost-iostreams-dev          \
-                    libboost-program-options-dev    \
                     libboost-regex-dev              \
-                    libboost-system-dev             \
-                    libboost-thread-dev             \
                     libgoogle-perftools-dev         \
                     mpi-default-dev                 \
-                    vc-dev                          \
-                    doxygen                         \
-                    python3                         \
-                    python3-pip                     \
-                    texlive                         \
-                    texlive-latex-extra             \
-                    latexmk                         \
-                    libjson-perl                    \
                     ninja-build                     \
+                    python3 python3-pip             \
                     codespell                       \
                     git                             \
                     xsltproc                        \
                     rpm                             \
-                    pkg-config                      \
                     graphviz                        \
                     iwyu                            \
-                    devscripts                      \
-                    wget
+                    devscripts
 
 # Get cmake files (in separate RUN command to get cached)
 RUN wget -q https://cmake.org/files/v3.19/cmake-3.19.8-Linux-x86_64.tar.gz -O cmake.tar.gz && \
@@ -81,33 +61,21 @@ RUN wget -q https://cmake.org/files/v3.19/cmake-3.19.8-Linux-x86_64.tar.gz -O cm
     tar --strip-components=1 -C /usr/local -xf cmake.tar.gz && \
     rm cmake.tar.gz
 
+# Install grcov and cpp-dependencies
 RUN wget -q https://github.com/mozilla/grcov/releases/download/v0.7.1/grcov-linux-x86_64.tar.bz2 -O grcov.tar.bz2 && \
     echo "603196293bed54d7ec6fb6d6f85db27966c4512235c7bd6555e1082e765c5bd2 grcov.tar.bz2" | sha256sum --check --status && \
     tar -jxf grcov.tar.bz2 && \
     mv grcov /usr/bin && \
     rm grcov.tar.bz2
 
-# NOTE: breathe is pinned to 4.16.0 as 4.17.0 introduced a regression in
-# handling "friend struct x;", see
-# https://github.com/michaeljones/breathe/issues/521. The pinned version can be
-# removed when the issue has been resolved.
-RUN pip3 install sphinx==3.5.4 breathe==4.16.0 sphinx-rtd-theme sphinx-book-theme sphinxcontrib-bibtex insegel cmake_format && \
-    rm /usr/bin/ld && ln -s /usr/bin/ld.lld /usr/bin/ld && cd /tmp && \
+RUN rm /usr/bin/ld && ln -s /usr/bin/ld.lld /usr/bin/ld && cd /tmp && \
     git clone https://github.com/tomtom-international/cpp-dependencies.git && \
-    cd cpp-dependencies && cmake . && make -j install && \
+    cd cpp-dependencies && cmake -DWITH_BOOST=OFF . && make -j install && \
     cd /tmp && rm -rf /tmp/cpp-dependencies && \
-    git clone --single-branch --branch clang_10 https://github.com/include-what-you-use/include-what-you-use.git && \
-    mkdir -p include-what-you-use/build && cd include-what-you-use/build && \
-    cmake -DCMAKE_PREFIX_PATH="/usr/lib/llvm-10" -DCMAKE_INSTALL_PREFIX="/usr" .. && make -j install && \
-    cd /tmp && rm -rf include-what-you-use && \
-    git clone --single-branch --branch 1.4.1 https://github.com/VcDevel/Vc.git && \
-    cd Vc && git submodule update --init && \
-    mkdir -p build && cd build && \
-    cmake -DBUILD_TESTING=OFF .. && make -j install && \
-    cd /tmp && rm -rf Vc && \
     rm -rf /var/lib/apt/lists/*
 
-ENV CC clang
+RUN pip3 install cmake_format
+
 ENV CXX clang++
 
 # IMPORTANT: Did you read the note at the top of the file?

--- a/Dockerfile.hip
+++ b/Dockerfile.hip
@@ -3,7 +3,9 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-FROM stellargroup/build_env:10
+ARG BASE_IMAGE
+
+FROM $BASE_IMAGE
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/Dockerfile.hip
+++ b/Dockerfile.hip
@@ -3,7 +3,9 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-FROM pikaorg/pika-ci-base:latest
+ARG BASE_IMAGE
+
+FROM $BASE_IMAGE
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/Dockerfile.hip
+++ b/Dockerfile.hip
@@ -3,9 +3,7 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-ARG BASE_IMAGE
-
-FROM $BASE_IMAGE
+FROM pikaorg/pika-ci-base:latest
 
 ENV DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
Remove obsolete dependencies like:
- asio
- boost (atomic, chrono, date-time, filesystem, iostreams, program-options, thread, system)
- packages related to docs (latex, doxygen, etc.), we can move this to a documentation image
- installation of include-what-you-use since the package `iwyu` is in the `apt install` list
- `wget` as duplicated
- `pkg-config` not in pika anymore
- `Vc` as we plan to remove its support in pika (replaced by `std::experimental::simd`)
- `kmod` and `jq` as used in `roll_release.sh`

Fixes partially https://github.com/pika-org/pika/issues/10

TODO:
- [x] Add a CI step to build the image
- [x] Test it with pika