### PR TITLE
Update to ubuntu 22.04 for MPI CI

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -14,8 +14,9 @@ on:
     branches: main
 
 env:
-  version: 3
+  base_image_version: 3
   base_image_name: pika-ci-base
+  hip_image_version: 2
   hip_image_name: pika-ci-hip
 
 jobs:
@@ -36,19 +37,19 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           file: Dockerfile.base
-          tags: ${{ secrets.DOCKER_USER }}/${{ env.base_image_name }}:latest,${{ secrets.DOCKER_USER }}/${{ env.base_image_name }}:${{ env.version }}
+          tags: ${{ secrets.DOCKER_USER }}/${{ env.base_image_name }}:latest,${{ secrets.DOCKER_USER }}/${{ env.base_image_name }}:${{ env.base_image_version }}
           load: true
       - name: Push base image
         uses: docker/build-push-action@v2
         if: ${{ github.ref == 'refs/heads/main' }}
         with:
           file: Dockerfile.base
-          tags: ${{ secrets.DOCKER_USER }}/${{ env.base_image_name }}:latest,${{ secrets.DOCKER_USER }}/${{ env.base_image_name }}:${{ env.version }}
+          tags: ${{ secrets.DOCKER_USER }}/${{ env.base_image_name }}:latest,${{ secrets.DOCKER_USER }}/${{ env.base_image_name }}:${{ env.base_image_version }}
           push: true
       - name: Build and deploy HIP image
         uses: docker/build-push-action@v2
         with:
           file: Dockerfile.hip
-          build-args: BASE_IMAGE=${{ secrets.DOCKER_USER }}/${{ env.base_image_name }}:${{ env.version }}
-          tags: ${{ secrets.DOCKER_USER }}/${{ env.hip_image_name }}:latest,${{ secrets.DOCKER_USER }}/${{ env.hip_image_name }}:${{ env.version }}
+          build-args: BASE_IMAGE=${{ secrets.DOCKER_USER }}/${{ env.base_image_name }}:${{ env.hip_image_version }}
+          tags: ${{ secrets.DOCKER_USER }}/${{ env.hip_image_name }}:latest,${{ secrets.DOCKER_USER }}/${{ env.hip_image_name }}:${{ env.hip_image_version }}
           push: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -14,7 +14,7 @@ on:
     branches: main
 
 env:
-  version: 2
+  version: 3
   base_image_name: pika-ci-base
   hip_image_name: pika-ci-hip
 

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -14,7 +14,7 @@
 # can be updated and tested in a separate PR without risking breaking open pull
 # request builds.
 
-FROM ubuntu:focal
+FROM ubuntu:jammy
 
 ENV DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
I opened #7 to try to fix the ROCm installation on ubuntu jammy, leaving the version 2 on ubuntu focal for HIP in this PR.