### PR TITLE
Actually add `fmt`

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -28,6 +28,7 @@ RUN apt-get update && \
       make \
       libboost-filesystem-dev \
       libboost-regex-dev \
+      libfmt-dev \
       libgoogle-perftools-dev \
       libhwloc-dev \
       lld \


### PR DESCRIPTION
I managed to remove `libfmt-dev` in #19 before merging. This adds it back.

Note: I'm not bumping the image version since it hasn't been put into use yet.