### PR TITLE
Update fmt to version 9

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -28,7 +28,6 @@ RUN apt-get update && \
       make \
       libboost-filesystem-dev \
       libboost-regex-dev \
-      libfmt-dev \
       libgoogle-perftools-dev \
       libhwloc-dev \
       lld \
@@ -79,7 +78,16 @@ RUN apt-get update && \
     cmake . && \
     make install && \
     cd /tmp && \
-    rm -rf /tmp/stdexec
+    rm -rf /tmp/stdexec && \
+    # Install fmt
+    cd /tmp && \
+    git clone https://github.com/fmtlib/fmt.git && \
+    cd fmt && \
+    git checkout 9.1.0 && \
+    cmake -DBUILD_SHARED_LIBS=ON . && \
+    make install && \
+    cd /tmp && \
+    rm -rf /tmp/fmt
 
 ENV CXX clang++
 


### PR DESCRIPTION
Once more attempt at `fmt`... It turns out that fmt 9 has some nice features that are worth having around. Since we're just starting out I think it makes sense to start with the latest major version.

I'm once again not bumping the image version since it hasn't been put into use yet.