### PR TITLE
Update inshpect

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -110,7 +110,7 @@ RUN apt-get update && \
     mv fd /usr/local/bin && \
     curl --output inshpect \
       --location https://raw.githubusercontent.com/msimberg/inshpect/main/inshpect && \
-    (echo "342158cddb11c31c75c917334eff1a91debdc210ae38ded1447a14065f205e78 inshpect" | sha256sum --check) && \
+    (echo "04b6160cc0b1a45a38db319617697a0bb6a0c1413313d945a4ba73811dd5288a inshpect" | sha256sum --check) && \
     chmod +x inshpect && \
     mv inshpect /usr/local/bin && \
     cd /tmp && \


### PR DESCRIPTION
`inshpect` was skipping some files when the `pragma_once` check was enabled. That was fixed in https://github.com/msimberg/inshpect/commit/f7b6045cdf832da30be1b0fb88a35827cc443ffa. This updates `inshpect` in the image. I'm _not_ bumping the image versions because nothing else has changed.