### PR TITLE
Fix CVE-2024-22365 related to libpam

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -15,7 +15,7 @@
 FROM ubuntu:jammy
 
 # Update and install libraries and tools from repositories
-RUN apt-get update && apt-get dist-upgrade libpam0g --yes && \
+RUN apt-get update && apt-get dist-upgrade --yes && \
     apt-get install --no-install-recommends --yes \
       bzip2 \
       clang \


### PR DESCRIPTION
https://security.snyk.io/vuln/SNYK-UBUNTU2204-PAM-6170208