### PR TITLE
Add hwloc executables to base image

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -14,7 +14,7 @@ on:
     branches: main
 
 env:
-  base_image_version: 22
+  base_image_version: 23
   base_image_name: pika-ci-base
   hip_base_image_version: 21
   hip_image_version: 14

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -27,6 +27,7 @@ RUN apt-get update && apt-get dist-upgrade --yes && \
       git \
       graphviz \
       grcov \
+      hwloc \
       make \
       libclang-rt-dev \
       libboost-filesystem-dev \


### PR DESCRIPTION
To make `hwloc-bind` etc. available for testing in CI.