### PR TITLE
Update HIP image again

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -17,7 +17,7 @@ env:
   base_image_version: 29
   base_image_name: pika-ci-base
   hip_base_image_version: 29
-  hip_image_version: 17
+  hip_image_version: 18
   hip_image_name: pika-ci-hip
 
 jobs:

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -34,15 +34,6 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_PASS }}
-      - name: Free disk space
-        uses: jlumbroso/free-disk-space@v1.3.1
-        with:
-          tool-cache: true
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: true
-          docker-images: true
       - name: Build base image
         uses: docker/build-push-action@v6
         with:

--- a/Dockerfile.hip
+++ b/Dockerfile.hip
@@ -22,7 +22,7 @@ RUN apt-get update && apt-get install -y wget gnupg && \
         | tee /etc/apt/preferences.d/rocm-pin-600 && \
     cat /etc/apt/preferences.d/rocm-pin-600 && \
     apt-get update -qq && \
-    apt-get install -y rocm rocblas git && \
+    apt-get install -y rocm-dev rocblas-dev rocsolver-dev && \
     rm -rf /var/lib/apt/lists/* && apt-get clean
 
 ENV ROCM_PATH=/opt/rocm


### PR DESCRIPTION
In #53 I installed way too many ROCm libraries. This slims it down to what @aurianer had already set up for the previous iteration. It also removes an extra `git` install that I had accidentally left in the HIP image build in #53.

I'm not updating the base image tag since it's unchanged (though a rebuild will be triggered, and a new image pushed).